### PR TITLE
open github ssh keys page and confirm key is authorised with sso

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -60,6 +60,10 @@ if kandji_installed && xcode_tools_installed && brew_installed; then
     gh auth login -p ssh -h github.com --insecure-storage -w
   fi
 
+  open https://github.com/settings/keys
+  notify "Please confirm your SSH Key has been Configured for SSO for the blake-education organization"
+  read -p "Press enter to continue"
+
   if [[ ! -d ~/Blake/bx ]]; then
     notify "Cloning bx repo."
     gh repo clone blake-education/bx ~/Blake/bx


### PR DESCRIPTION
If the user uploads a new ssh key, they will need to go to https://github.com/settings/keys and Configure SSO on their new key to Authorize the blake-education organization.